### PR TITLE
Removing "properties" and adding GOMAXPROCS as envar

### DIFF
--- a/cmd/tilenol/main.go
+++ b/cmd/tilenol/main.go
@@ -1,57 +1,56 @@
 package main
 
 import (
-	"fmt"
-	"runtime"
+    "fmt"
 
-	"github.com/stationa/tilenol/server"
-	"gopkg.in/alecthomas/kingpin.v2"
+    "github.com/stationa/tilenol/server"
+    "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
-	runCmd = kingpin.
-		Command("run", "Runs the Tilenol server")
-	esHost = runCmd.
-		Flag("es-host", "ElasticSearch host-port").
-		Envar("TILENOL_ES_HOST").
-		Short('e').
-		Default("localhost:9200").
-		String()
-	esMap = runCmd.
-		Flag("es-mappings", "ElasticSearch index name to geo-field mappings").
-		Short('m').
-		Default("_all=geometry").
-		StringMap()
-	zoomRanges = runCmd.
-			Flag("zoom-ranges", "ElasticSearch index name to zoom range mappings").
-			Short('Z').
-			Default("_all=0-18").
-			StringMap()
-	port = runCmd.
-		Flag("port", "Port to serve tiles on").
-		Envar("TILENOL_PORT").
-		Short('p').
-		Default("3000").
-		Uint16()
-	internalPort = runCmd.
-			Flag("internal-port", "Port for internal metrics and healthchecks").
-			Envar("TILENOL_INTERNAL_PORT").
-			Short('i').
-			Default("3001").
-			Uint16()
-	cors = runCmd.
-		Flag("enable-cors", "Enables cross-origin resource sharing (CORS)").
-		Envar("TILENOL_ENABLE_CORS").
-		Short('x').
-		Bool()
-	cache = runCmd.
-		Flag("cache-control", "Sets the \"Cache-Control\" header").
-		Envar("TILENOL_CACHE_CONTROL").
-		Short('c').
-		Default("no-cache").
-		String()
-	versionCmd = kingpin.
-			Command("version", "Prints out the version")
+    runCmd = kingpin.
+        Command("run", "Runs the Tilenol server")
+    esHost = runCmd.
+        Flag("es-host", "ElasticSearch host-port").
+        Envar("TILENOL_ES_HOST").
+        Short('e').
+        Default("localhost:9200").
+        String()
+    esMap = runCmd.
+        Flag("es-mappings", "ElasticSearch index name to geo-field mappings").
+        Short('m').
+        Default("_all=geometry").
+        StringMap()
+    zoomRanges = runCmd.
+        Flag("zoom-ranges", "ElasticSearch index name to zoom range mappings").
+        Short('Z').
+        Default("_all=0-18").
+        StringMap()
+    port = runCmd.
+        Flag("port", "Port to serve tiles on").
+        Envar("TILENOL_PORT").
+        Short('p').
+        Default("3000").
+        Uint16()
+    internalPort = runCmd.
+        Flag("internal-port", "Port for internal metrics and healthchecks").
+        Envar("TILENOL_INTERNAL_PORT").
+        Short('i').
+        Default("3001").
+        Uint16()
+    cors = runCmd.
+        Flag("enable-cors", "Enables cross-origin resource sharing (CORS)").
+        Envar("TILENOL_ENABLE_CORS").
+        Short('x').
+        Bool()
+    cache = runCmd.
+        Flag("cache-control", "Sets the \"Cache-Control\" header").
+        Envar("TILENOL_CACHE_CONTROL").
+        Short('c').
+        Default("no-cache").
+        String()
+    versionCmd = kingpin.
+        Command("version", "Prints out the version")
 )
 
 // Auto-filled by build
@@ -59,34 +58,31 @@ var Version string
 var Commitish string
 
 func PrintVersionInfo() {
-	fmt.Printf("tilenol version=%s (%s)\n", Version, Commitish)
+    fmt.Printf("tilenol version=%s (%s)\n", Version, Commitish)
 }
 
 func main() {
-	numCores := runtime.NumCPU()
-	runtime.GOMAXPROCS(numCores)
+    cmd := kingpin.Parse()
 
-	cmd := kingpin.Parse()
+    switch cmd {
+    case runCmd.FullCommand():
+        var opts []server.ConfigOption
+        opts = append(opts, server.Port(*port))
+        opts = append(opts, server.InternalPort(*internalPort))
+        opts = append(opts, server.CacheControl(*cache))
+        opts = append(opts, server.ESHost(*esHost))
+        opts = append(opts, server.ESMappings(*esMap))
+        opts = append(opts, server.ZoomRanges(*zoomRanges))
+        if *cors {
+            opts = append(opts, server.EnableCORS)
+        }
 
-	switch cmd {
-	case runCmd.FullCommand():
-		var opts []server.ConfigOption
-		opts = append(opts, server.Port(*port))
-		opts = append(opts, server.InternalPort(*internalPort))
-		opts = append(opts, server.CacheControl(*cache))
-		opts = append(opts, server.ESHost(*esHost))
-		opts = append(opts, server.ESMappings(*esMap))
-		opts = append(opts, server.ZoomRanges(*zoomRanges))
-		if *cors {
-			opts = append(opts, server.EnableCORS)
-		}
-
-		s, err := server.NewServer(opts...)
-		if err != nil {
-			panic(err)
-		}
-		s.Start()
-	case versionCmd.FullCommand():
-		PrintVersionInfo()
-	}
+        s, err := server.NewServer(opts...)
+        if err != nil {
+            panic(err)
+        }
+        s.Start()
+    case versionCmd.FullCommand():
+        PrintVersionInfo()
+    }
 }

--- a/cmd/tilenol/main.go
+++ b/cmd/tilenol/main.go
@@ -69,11 +69,10 @@ func PrintVersionInfo() {
 }
 
 func main() {
-	numCores := runtime.NumCPU()
 	if *numProcs < 1 {
-		*numProcs = numCores
+		*numProcs = runtime.NumCPU()
 	}
-	runtime.GOMAXPROCS(numCores)
+	runtime.GOMAXPROCS(*numProcs)
 
 	cmd := kingpin.Parse()
 

--- a/cmd/tilenol/main.go
+++ b/cmd/tilenol/main.go
@@ -1,56 +1,63 @@
 package main
 
 import (
-    "fmt"
+	"fmt"
+	"runtime"
 
-    "github.com/stationa/tilenol/server"
-    "gopkg.in/alecthomas/kingpin.v2"
+	"github.com/stationa/tilenol/server"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
-    runCmd = kingpin.
-        Command("run", "Runs the Tilenol server")
-    esHost = runCmd.
-        Flag("es-host", "ElasticSearch host-port").
-        Envar("TILENOL_ES_HOST").
-        Short('e').
-        Default("localhost:9200").
-        String()
-    esMap = runCmd.
-        Flag("es-mappings", "ElasticSearch index name to geo-field mappings").
-        Short('m').
-        Default("_all=geometry").
-        StringMap()
-    zoomRanges = runCmd.
-        Flag("zoom-ranges", "ElasticSearch index name to zoom range mappings").
-        Short('Z').
-        Default("_all=0-18").
-        StringMap()
-    port = runCmd.
-        Flag("port", "Port to serve tiles on").
-        Envar("TILENOL_PORT").
-        Short('p').
-        Default("3000").
-        Uint16()
-    internalPort = runCmd.
-        Flag("internal-port", "Port for internal metrics and healthchecks").
-        Envar("TILENOL_INTERNAL_PORT").
-        Short('i').
-        Default("3001").
-        Uint16()
-    cors = runCmd.
-        Flag("enable-cors", "Enables cross-origin resource sharing (CORS)").
-        Envar("TILENOL_ENABLE_CORS").
-        Short('x').
-        Bool()
-    cache = runCmd.
-        Flag("cache-control", "Sets the \"Cache-Control\" header").
-        Envar("TILENOL_CACHE_CONTROL").
-        Short('c').
-        Default("no-cache").
-        String()
-    versionCmd = kingpin.
-        Command("version", "Prints out the version")
+	runCmd = kingpin.
+		Command("run", "Runs the Tilenol server")
+	esHost = runCmd.
+		Flag("es-host", "ElasticSearch host-port").
+		Envar("TILENOL_ES_HOST").
+		Short('e').
+		Default("localhost:9200").
+		String()
+	esMap = runCmd.
+		Flag("es-mappings", "ElasticSearch index name to geo-field mappings").
+		Short('m').
+		Default("_all=geometry").
+		StringMap()
+	zoomRanges = runCmd.
+			Flag("zoom-ranges", "ElasticSearch index name to zoom range mappings").
+			Short('Z').
+			Default("_all=0-18").
+			StringMap()
+	port = runCmd.
+		Flag("port", "Port to serve tiles on").
+		Envar("TILENOL_PORT").
+		Short('p').
+		Default("3000").
+		Uint16()
+	internalPort = runCmd.
+			Flag("internal-port", "Port for internal metrics and healthchecks").
+			Envar("TILENOL_INTERNAL_PORT").
+			Short('i').
+			Default("3001").
+			Uint16()
+	cors = runCmd.
+		Flag("enable-cors", "Enables cross-origin resource sharing (CORS)").
+		Envar("TILENOL_ENABLE_CORS").
+		Short('x').
+		Bool()
+	cache = runCmd.
+		Flag("cache-control", "Sets the \"Cache-Control\" header").
+		Envar("TILENOL_CACHE_CONTROL").
+		Short('c').
+		Default("no-cache").
+		String()
+	numCores = runCmd.
+			Flag("num-cores", "Sets the number of CPU cores to be used").
+			Envar("TILENOL_NUM_CORES").
+			Short('n').
+			Default("1").
+			Int()
+	versionCmd = kingpin.
+			Command("version", "Prints out the version")
 )
 
 // Auto-filled by build
@@ -58,31 +65,33 @@ var Version string
 var Commitish string
 
 func PrintVersionInfo() {
-    fmt.Printf("tilenol version=%s (%s)\n", Version, Commitish)
+	fmt.Printf("tilenol version=%s (%s)\n", Version, Commitish)
 }
 
 func main() {
-    cmd := kingpin.Parse()
+	runtime.GOMAXPROCS(*numCores)
 
-    switch cmd {
-    case runCmd.FullCommand():
-        var opts []server.ConfigOption
-        opts = append(opts, server.Port(*port))
-        opts = append(opts, server.InternalPort(*internalPort))
-        opts = append(opts, server.CacheControl(*cache))
-        opts = append(opts, server.ESHost(*esHost))
-        opts = append(opts, server.ESMappings(*esMap))
-        opts = append(opts, server.ZoomRanges(*zoomRanges))
-        if *cors {
-            opts = append(opts, server.EnableCORS)
-        }
+	cmd := kingpin.Parse()
 
-        s, err := server.NewServer(opts...)
-        if err != nil {
-            panic(err)
-        }
-        s.Start()
-    case versionCmd.FullCommand():
-        PrintVersionInfo()
-    }
+	switch cmd {
+	case runCmd.FullCommand():
+		var opts []server.ConfigOption
+		opts = append(opts, server.Port(*port))
+		opts = append(opts, server.InternalPort(*internalPort))
+		opts = append(opts, server.CacheControl(*cache))
+		opts = append(opts, server.ESHost(*esHost))
+		opts = append(opts, server.ESMappings(*esMap))
+		opts = append(opts, server.ZoomRanges(*zoomRanges))
+		if *cors {
+			opts = append(opts, server.EnableCORS)
+		}
+
+		s, err := server.NewServer(opts...)
+		if err != nil {
+			panic(err)
+		}
+		s.Start()
+	case versionCmd.FullCommand():
+		PrintVersionInfo()
+	}
 }

--- a/cmd/tilenol/main.go
+++ b/cmd/tilenol/main.go
@@ -50,11 +50,11 @@ var (
 		Short('c').
 		Default("no-cache").
 		String()
-	numCores = runCmd.
-			Flag("num-cores", "Sets the number of CPU cores to be used").
-			Envar("TILENOL_NUM_CORES").
+	numProcs = runCmd.
+			Flag("num-processes", "Sets the number of processes to be used").
+			Envar("TILENOL_NUM_PROCESSES").
 			Short('n').
-			Default("1").
+			Default("0").
 			Int()
 	versionCmd = kingpin.
 			Command("version", "Prints out the version")
@@ -69,7 +69,11 @@ func PrintVersionInfo() {
 }
 
 func main() {
-	runtime.GOMAXPROCS(*numCores)
+	numCores := runtime.NumCPU()
+	if *numProcs < 1 {
+		*numProcs = numCores
+	}
+	runtime.GOMAXPROCS(numCores)
 
 	cmd := kingpin.Parse()
 

--- a/server/es.go
+++ b/server/es.go
@@ -19,7 +19,7 @@ const (
 )
 
 func buildQuery(geometryField string, extraSources []string, tileBounds orb.Bound) interface{} {
-	sourceParam := append(extraSources, "properties", geometryField)
+	sourceParam := append(extraSources, geometryField)
 	return map[string]interface{}{
 		"query": map[string]interface{}{
 			"bool": map[string]interface{}{


### PR DESCRIPTION
Tiny changeset that does 2 things:
* Removes `"properties"` as a default field to be returned by ES
* Allows configuring the `GOMAXPROCS` variable through the environment