### PR TITLE
Adds "-s" toggle to enable shape simplification (defaults to false)

### DIFF
--- a/cmd/tilenol/main.go
+++ b/cmd/tilenol/main.go
@@ -49,6 +49,11 @@ var (
 		Envar("TILENOL_ENABLE_CORS").
 		Short('x').
 		Bool()
+	simplify = runCmd.
+			Flag("simplify-shapes", "Simplifies geometries based on zoome level").
+			Envar("TILENOL_SIMPLIFY_SHAPES").
+			Short('s').
+			Bool()
 	cache = runCmd.
 		Flag("cache-control", "Sets the \"Cache-Control\" header").
 		Envar("TILENOL_CACHE_CONTROL").
@@ -100,6 +105,9 @@ func main() {
 		opts = append(opts, server.ZoomRanges(*zoomRanges))
 		if *cors {
 			opts = append(opts, server.EnableCORS)
+		}
+		if *simplify {
+			opts = append(opts, server.SimplifyShapes)
 		}
 
 		s, err := server.NewServer(opts...)

--- a/server/config.go
+++ b/server/config.go
@@ -34,6 +34,12 @@ func EnableCORS(s *Server) error {
 	return nil
 }
 
+// Simplify shapes enable geometry simplification based on the requested zoom level
+func SimplifyShapes(s *Server) error {
+	s.Simplify = true
+	return nil
+}
+
 // CacheControl sets a fixed string to be used for the Cache-Control HTTP header
 func CacheControl(cacheControl string) ConfigOption {
 	return func(s *Server) error {


### PR DESCRIPTION
In running performance tests, I've found that contrary to the suggestions made in #3,
the better solution in most cases is to not do shape simplification at all, which
reduces CPU loads at the cost of network payload size (since the result is technically
higher-fidelity vector geometries). That said, this has the practical advantage of
reducing latency on higher-bandwidth network connections, by relying more heavily on
network optimizations (caching, compression, etc.).