### PR TITLE
[CI] Update Travis CI config to build the Docker image per #8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: go
-go:
-  - 1.11.x
-  - 1.12.x
-
-before_install:
-  - curl -L -s https://github.com/golang/dep/releases/download/v0.5.1/dep-linux-amd64 -o $GOPATH/bin/dep
-  - chmod +x $GOPATH/bin/dep
+services:
+  - docker
+script:
+  - docker build -t stationa/tilenol:latest .


### PR DESCRIPTION
This small change updates our Travis CI build configuration to attempt to build the Docker image, which in itself manages to isolate the build environment, compile the code, and run unit tests.

This config does not yet automatically publish builds to Github or Dockerhub, but I figure we can defer that to a later time.