### PR TITLE
Implements basic support for Elasticsearch "query_string_query" per #20

### DIFF
--- a/es_source.go
+++ b/es_source.go
@@ -137,7 +137,7 @@ func boundsFilter(geometryField string, tile maptile.Tile) *Dict {
 // within the tile boundaries
 func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
 	var query = elastic.NewBoolQuery().Filter(boundsFilter(e.GeometryField, req.MapTile()))
-	if qs := req.Request.URL.Query().Get("q"); qs != "" {
+	if qs, exists := req.Args["q"]; exists && qs != "" {
 		query = query.Filter(elastic.NewQueryStringQuery(qs))
 	}
 	ss := e.newSearchSource(query)

--- a/es_source.go
+++ b/es_source.go
@@ -136,7 +136,10 @@ func boundsFilter(geometryField string, tile maptile.Tile) *Dict {
 // doGetFeatures scrolls the configured Elasticsearch index for all documents that fall
 // within the tile boundaries
 func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
-	query := elastic.NewBoolQuery().Filter(boundsFilter(e.GeometryField, req.MapTile()))
+	var query = elastic.NewBoolQuery().Filter(boundsFilter(e.GeometryField, req.MapTile()))
+	if qs := req.Request.URL.Query().Get("q"); qs != "" {
+		query = query.Filter(elastic.NewQueryStringQuery(qs))
+	}
 	ss := e.newSearchSource(query)
 	s, _ := ss.Source()
 	Logger.Debugf("Search source: %#v", s)

--- a/server.go
+++ b/server.go
@@ -34,10 +34,10 @@ const (
 
 // TileRequest is an object containing the tile request context
 type TileRequest struct {
-	Request *http.Request
-	X       int
-	Y       int
-	Z       int
+	X    int
+	Y    int
+	Z    int
+	Args map[string]string
 }
 
 // Error type for HTTP Status code 400
@@ -62,7 +62,12 @@ func MakeTileRequest(req *http.Request, x int, y int, z int) (*TileRequest, erro
 		return nil, InvalidRequestError{fmt.Sprintf("Invalid Y value [%d] for zoom level [%d].", y, z)}
 	}
 
-	return &TileRequest{req, x, y, z}, nil
+	args := make(map[string]string)
+	for k, values := range req.URL.Query() {
+		args[k] = values[0] // TODO: Should we consider supporting multi-parameters?
+	}
+
+	return &TileRequest{x, y, z, args}, nil
 }
 
 // MapTile creates a maptile.Tile object from the TileRequest


### PR DESCRIPTION
Partially imports simple layer filtering support (as described in #20) by exposing and optional query parameter `q`. This parameter is used as-is to form an [Elasticsearch `query_string_query`](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html), supporting Lucene query syntax.

Below is an example of this is in action using pre-indexed OSM building data and real-time filtering based on the street name of the building address:

![tilenol-qsq](https://user-images.githubusercontent.com/745427/90940711-98826900-e3c4-11ea-991a-030b79e485e1.gif)

Eventually, it would be good to convert this field such that it could be used for an arbitrary ES query, but for now this gives us some simple filtering in a fairly straightforward fashion.

