### PR TITLE
Add request parameter to query extra source fields.

### DIFF
--- a/es_source.go
+++ b/es_source.go
@@ -153,7 +153,7 @@ func boundsFilter(geometryField string, tile maptile.Tile) *Dict {
 }
 
 // Given the list of extra source arguments that were specified with request, transform
-// these into a map of property name to ES document source path, or return an erorr
+// these into a map of property name to ES document source path, or return an error
 // if there is a malformed extra source argument.
 func makeFieldMap(incArgs []string) (map[string]string, error) {
 	var result = make(map[string]string);

--- a/es_source.go
+++ b/es_source.go
@@ -92,10 +92,10 @@ func NewElasticsearchSource(config *ElasticsearchConfig) (Source, error) {
 func (e *ElasticsearchSource) addExtraFields(extraFields map[string]string) *ElasticsearchSource {
 	sourceFields := make(map[string]string)
 	for k, v := range e.SourceFields {
-		sourceFields[k] = v;
+		sourceFields[k] = v
 	}
 	for k, v := range extraFields {
-		sourceFields[k] = v;
+		sourceFields[k] = v
 	}
 	return &ElasticsearchSource{
 		ES:            e.ES,
@@ -104,7 +104,6 @@ func (e *ElasticsearchSource) addExtraFields(extraFields map[string]string) *Ela
 		SourceFields:  sourceFields,
 	}
 }
-
 
 // GetFeatures implements the Source interface, to get feature data from an
 // Elasticsearch cluster
@@ -156,17 +155,17 @@ func boundsFilter(geometryField string, tile maptile.Tile) *Dict {
 // these into a map of property name to ES document source path, or return an error
 // if there is a malformed extra source argument.
 func makeFieldMap(incArgs []string) (map[string]string, error) {
-	var result = make(map[string]string);
+	var result = make(map[string]string)
 
 	for _, source := range incArgs {
-		splits := strings.SplitN(source, ":", 2);
+		splits := strings.SplitN(source, ":", 2)
 		if len(splits) < 2 {
-			return nil, InvalidRequestError{fmt.Sprintf("Invalid source field specification: '%s'", source)};
+			return nil, InvalidRequestError{fmt.Sprintf("Invalid source field specification: '%s'", source)}
 		}
-		result[splits[0]] = splits[1];
+		result[splits[0]] = splits[1]
 	}
 
-	return result, nil;
+	return result, nil
 }
 
 // doGetFeatures scrolls the configured Elasticsearch index for all documents that fall
@@ -181,13 +180,13 @@ func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileReques
 	// Check for extra fields specifications. They must have the form of <property_name>:<ES_document_path>,
 	// eg: levels:building.stories.
 	if inc_args, exists := req.Args["s"]; exists {
-		extraFields, err := makeFieldMap(inc_args);
+		extraFields, err := makeFieldMap(inc_args)
 		if err != nil {
-			return nil, err;
+			return nil, err
 		}
 		// Instead of the original ElasticsearchSource use one that is augmented with the extra
 		// source field requests for the remainder of this request.
-		e = e.addExtraFields(extraFields);
+		e = e.addExtraFields(extraFields)
 	}
 
 	ss := e.newSearchSource(query)

--- a/es_source.go
+++ b/es_source.go
@@ -87,6 +87,25 @@ func NewElasticsearchSource(config *ElasticsearchConfig) (Source, error) {
 	}, nil
 }
 
+// Create a new ElasticsearchSource from the input object, but add extra features
+// to include to the new ElasticsearchSource instance.
+func (e *ElasticsearchSource) addExtraFeatures(extraFeatures map[string]string) *ElasticsearchSource {
+	sourceFields := make(map[string]string)
+	for k, v := range e.SourceFields {
+		sourceFields[k] = v;
+	}
+	for k, v := range extraFeatures {
+		sourceFields[k] = v;
+	}
+	return &ElasticsearchSource{
+		ES:            e.ES,
+		Index:         e.Index,
+		GeometryField: e.GeometryField,
+		SourceFields:  sourceFields,
+	}
+}
+
+
 // GetFeatures implements the Source interface, to get feature data from an
 // Elasticsearch cluster
 func (e *ElasticsearchSource) GetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
@@ -133,13 +152,44 @@ func boundsFilter(geometryField string, tile maptile.Tile) *Dict {
 	}
 }
 
+// Given the list of extra source arguments that were specified with request, transform
+// these into a map of property name to ES document source path, or return an erorr
+// if there is a malformed extra source argument.
+func makeFieldMap(incArgs []string) (map[string]string, error) {
+	var result = make(map[string]string);
+
+	for _, source := range incArgs {
+		splits := strings.SplitN(source, ":", 2);
+		if len(splits) < 2 {
+			return nil, InvalidRequestError{fmt.Sprintf("Invalid source field specification: '%s'", source)};
+		}
+		result[splits[0]] = splits[1];
+	}
+
+	return result, nil;
+}
+
 // doGetFeatures scrolls the configured Elasticsearch index for all documents that fall
 // within the tile boundaries
 func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
+	// Check for optional ES query argument.
 	var query = elastic.NewBoolQuery().Filter(boundsFilter(e.GeometryField, req.MapTile()))
-	if qs, exists := req.Args["q"]; exists && qs != "" {
-		query = query.Filter(elastic.NewQueryStringQuery(qs))
+	if qs, exists := req.Args["q"]; exists && qs[0] != "" { // TODO: We ignore all but the first "q" arg.
+		query = query.Filter(elastic.NewQueryStringQuery(qs[0]))
 	}
+
+	// Check for extra fields specifications. They must have the form of <property_name>:<ES_document_path>,
+	// eg: levels:building.stories.
+	if inc_args, exists := req.Args["s"]; exists {
+		extraFields, err := makeFieldMap(inc_args);
+		if err != nil {
+			return nil, err;
+		}
+		// Instead of the original ElasticsearchSource use one that is augmented with the extra
+		// source field requests for the remainder of this request.
+		e = e.addExtraFeatures(extraFields);
+	}
+
 	ss := e.newSearchSource(query)
 	s, _ := ss.Source()
 	Logger.Debugf("Search source: %#v", s)

--- a/es_source.go
+++ b/es_source.go
@@ -89,7 +89,7 @@ func NewElasticsearchSource(config *ElasticsearchConfig) (Source, error) {
 
 // Create a new ElasticsearchSource from the input object, but add extra SourceFields
 // to include to the new ElasticsearchSource instance.
-func (e *ElasticsearchSource) addExtraFields(extraFields map[string]string) *ElasticsearchSource {
+func (e *ElasticsearchSource) withExtraFields(extraFields map[string]string) *ElasticsearchSource {
 	sourceFields := make(map[string]string)
 	for k, v := range e.SourceFields {
 		sourceFields[k] = v
@@ -173,7 +173,7 @@ func makeFieldMap(incArgs []string) (map[string]string, error) {
 func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
 	// Check for optional ES query argument.
 	var query = elastic.NewBoolQuery().Filter(boundsFilter(e.GeometryField, req.MapTile()))
-	if qs, exists := req.Args["q"]; exists && qs[0] != "" { // TODO: We ignore all but the first "q" arg.
+	if qs, exists := req.Args["q"]; exists && len(qs) > 0 { // TODO: We ignore all but the first "q" arg.
 		query = query.Filter(elastic.NewQueryStringQuery(qs[0]))
 	}
 
@@ -186,7 +186,7 @@ func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileReques
 		}
 		// Instead of the original ElasticsearchSource use one that is augmented with the extra
 		// source field requests for the remainder of this request.
-		e = e.addExtraFields(extraFields)
+		e = e.withExtraFields(extraFields)
 	}
 
 	ss := e.newSearchSource(query)

--- a/es_source.go
+++ b/es_source.go
@@ -87,14 +87,14 @@ func NewElasticsearchSource(config *ElasticsearchConfig) (Source, error) {
 	}, nil
 }
 
-// Create a new ElasticsearchSource from the input object, but add extra features
+// Create a new ElasticsearchSource from the input object, but add extra SourceFields
 // to include to the new ElasticsearchSource instance.
-func (e *ElasticsearchSource) addExtraFeatures(extraFeatures map[string]string) *ElasticsearchSource {
+func (e *ElasticsearchSource) addExtraFields(extraFields map[string]string) *ElasticsearchSource {
 	sourceFields := make(map[string]string)
 	for k, v := range e.SourceFields {
 		sourceFields[k] = v;
 	}
-	for k, v := range extraFeatures {
+	for k, v := range extraFields {
 		sourceFields[k] = v;
 	}
 	return &ElasticsearchSource{
@@ -187,7 +187,7 @@ func (e *ElasticsearchSource) doGetFeatures(ctx context.Context, req *TileReques
 		}
 		// Instead of the original ElasticsearchSource use one that is augmented with the extra
 		// source field requests for the remainder of this request.
-		e = e.addExtraFeatures(extraFields);
+		e = e.addExtraFields(extraFields);
 	}
 
 	ss := e.newSearchSource(query)

--- a/server.go
+++ b/server.go
@@ -37,7 +37,7 @@ type TileRequest struct {
 	X    int
 	Y    int
 	Z    int
-	Args map[string]string
+	Args map[string][]string
 }
 
 // Error type for HTTP Status code 400
@@ -62,9 +62,9 @@ func MakeTileRequest(req *http.Request, x int, y int, z int) (*TileRequest, erro
 		return nil, InvalidRequestError{fmt.Sprintf("Invalid Y value [%d] for zoom level [%d].", y, z)}
 	}
 
-	args := make(map[string]string)
+	args := make(map[string][]string)
 	for k, values := range req.URL.Query() {
-		args[k] = values[0] // TODO: Should we consider supporting multi-parameters?
+		args[k] = values
 	}
 
 	return &TileRequest{x, y, z, args}, nil


### PR DESCRIPTION
# Description

This PR addresses issue #28, by adding support for a matrixed `s` query parameter when rquesting a tile. -- This allows for additional properties to be added to features, beyond what's specified in the layer defintion.

For example, a request like
```
http://mytilenolserver.company.com/_all/16/10486/25327.mvt?s=foo:bar&s=name:nested.property
```
will also add properties named `foo` and `name` to each feature on each layer, populating them from ES source fields `bar` and `nested.property`, respectively.

## RFC

These additional properties are currently applied across all requested layers. -- We could enhance this by making the source field parameter layer specific, such as `<layername>:<propertyname>:<elastic_source_field_path>`, with `_all` for `<layername>`  referring to all layers again.

## Implementation

The cleanest way to add support for this was to construct a new, temporary `ElasticsearchSource` instance for the lifetime of a request that has extra source field requests in `doGetFeature`. -- That temporary `ElasticsearchSource` contains those extra source fields and is then used for the remainder of the request, hence making the addition of extra fields transparent to the rest of the code.

## Testing Done

* Panning around on a map and using a URL that passes extra source field requests to `tilenol` and then confirming that they get properly attached to features.
* Using `wget` to poke `tilenol` directly to test queries that do not use this new feature still work, and that malformed `s` arguments return an HTTP 400 error.