### PR TITLE
validate layer config zoom values are within min/max bounds

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -9,8 +9,10 @@ import (
 )
 
 var (
-	MultipleSourcesErr = errors.New("Layers can only support a single backend source")
-	NoSourcesErr       = errors.New("Layers must have a single backend source configured")
+	MultipleSourcesErr         = errors.New("Layers can only support a single backend source")
+	NoSourcesErr               = errors.New("Layers must have a single backend source configured")
+	LayerMinZoomOutOfBoundsErr = errors.New("Layer Min zoom is below absolute min zoom")
+	LayerMaxZoomOutOfBoundsErr = errors.New("Layer Max Zoom is above absolute max zoom")
 )
 
 // SourceConfig represents a generic YAML source configuration object
@@ -64,6 +66,12 @@ func CreateLayer(layerConfig LayerConfig) (*Layer, error) {
 	}
 	if layerConfig.Source.Elasticsearch == nil && layerConfig.Source.PostGIS == nil {
 		return nil, NoSourcesErr
+	}
+	if layerConfig.Minzoom < MinZoom {
+		return nil, LayerMinZoomOutOfBoundsErr
+	}
+	if layerConfig.Maxzoom > MaxZoom {
+		return nil, LayerMaxZoomOutOfBoundsErr
 	}
 	if layerConfig.Source.Elasticsearch != nil {
 		source, err := NewElasticsearchSource(layerConfig.Source.Elasticsearch)

--- a/layer_test.go
+++ b/layer_test.go
@@ -24,3 +24,26 @@ func TestCreateLayerNoSources(t *testing.T) {
 	_, err := CreateLayer(config)
 	assert.Equal(t, NoSourcesErr, err, "Expected to fail due to no sources for layer")
 }
+
+func TestCreateLayerMinZoomOutOfBounds(t *testing.T) {
+	config := LayerConfig{
+		Minzoom: MinZoom - 1,
+		Maxzoom: MaxZoom - 1,
+		Source: SourceConfig{
+			Elasticsearch: new(ElasticsearchConfig),
+		},
+	}
+	_, err := CreateLayer(config)
+	assert.Equal(t, LayerMinZoomOutOfBoundsErr, err, "Expected to fail because layer min zoom is less than absolute allowed min")
+}
+func TestCreateLayerMaxZoomOutOfBounds(t *testing.T) {
+	config := LayerConfig{
+		Minzoom: MinZoom + 1,
+		Maxzoom: MaxZoom + 1,
+		Source: SourceConfig{
+			Elasticsearch: new(ElasticsearchConfig),
+		},
+	}
+	_, err := CreateLayer(config)
+	assert.Equal(t, LayerMaxZoomOutOfBoundsErr, err, "Expected to fail because layer max zoom is greater than absolute allowed max")
+}

--- a/server.go
+++ b/server.go
@@ -20,9 +20,13 @@ import (
 )
 
 const (
-	// MinZoom is the default minimum zoom for a layer
+	// MinZoom is the absolute minimum zoom for a layer
+	//  tile requests with z-values lower than this will be rejected
+	//  layer configurations with Minzoom values lower than this will be rejected
 	MinZoom = 0
-	// MaxZoom is the default maximum zoom for a layer
+	// MaxZoom is the absolute maximum zoom for a layer
+	//  tile requests with z-values higher than this will be rejected
+	//  layer configurations with Maxzoom values lower than this will be rejected
 	MaxZoom = 22
 	// MinSimplify is the minimum simplification radius
 	MinSimplify = 1.0


### PR DESCRIPTION
resolves #24 

[As discussed](https://github.com/StationA/tilenol/issues/24#issuecomment-723510924), layer configurations with minzoom values below the `MinZoom` server configuration or maxzoom values above the `MaxZoom` server configuration will trigger a panic at startup. 

I added a couple tests and updated the comments describing `MinZoom`/`MaxZoom` to add some more clarity, based on conversation thread referenced above.