### PR TITLE
[issue 39] Remove unneeded tx.Rollback.

### DIFF
--- a/postgis_source.go
+++ b/postgis_source.go
@@ -198,8 +198,10 @@ func (p *PostGISSource) runQuery(ctx context.Context, q string) ([]map[string]in
 	// Use a read-only transaction to ensure that we can't execute write operations to the database
 	txOps := &sql.TxOptions{ReadOnly: true}
 	tx, err := p.DB.BeginTx(qCtx, txOps)
-	// "Roll back" the transaction here just to ensure that any writes are not committed
-	defer tx.Rollback()
+	// Note that the database backend will rollback the transaction upon context cancellation.
+	if err != nil {
+		return nil, err
+	}
 
 	// Actually execute the query
 	Logger.Debugf("Executing SQL: %s\n", q)


### PR DESCRIPTION
# Description

This PR resolves issue #39, which is a case that gets hit if a tile request is canceled while we are still processing the [BeginTx](https://github.com/StationA/tilenol/blob/02e0a3b173b201974d1ee96f5da704edb99e7be1/postgis_source.go#L200) call.

In that case `nil` is returned for `tx` (and `err` is non-`nil`) and we crash as described in #39.

This PR fixes the issue by exiting `runQuery` if `BeginTx` returns an error and removing the call to `tx.Rollback` altogether.

Note that *not* calling `tx.Rollback` at all is OK because
* At this time we already have a [defered call to cancel](https://github.com/StationA/tilenol/blob/02e0a3b173b201974d1ee96f5da704edb99e7be1/postgis_source.go#L196) the Context on which the transaction was created.
* According to the [documentation on `database/sql.BeginTx`](https://golang.org/pkg/database/sql/#Conn.BeginTx): *If the context is canceled, the sql package will roll back the transaction.*

This implies that the transaction will always be rolled back without an explicit call to `tx.Rollback`.

Thanks to @audreyyku and @jerluc for their help with this!