### PR TITLE
Cache-per-layer

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -1,7 +1,10 @@
 package tilenol
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/gob"
 	"errors"
 	"fmt"
 
@@ -82,4 +85,18 @@ func CreateLayer(layerConfig LayerConfig) (*Layer, error) {
 		return layer, nil
 	}
 	return nil, fmt.Errorf("Invalid layer source config for layer: %s", layerConfig.Name)
+}
+
+func (l Layer) Hash() string {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	enc.Encode(l)
+	hash := sha256.New()
+	hash.Write(buf.Bytes())
+	hashBytes := hash.Sum(nil)
+	return fmt.Sprintf("%x", hashBytes)
+}
+
+func (l Layer) String() string {
+	return fmt.Sprintf("%s@%s", l.Name, l.Hash())
 }

--- a/layer.go
+++ b/layer.go
@@ -34,6 +34,8 @@ type LayerConfig struct {
 	Minzoom int `yaml:"minzoom"`
 	// Maxzoom specifies the maximum z value for the layer
 	Maxzoom int `yaml:"maxzoom"`
+	// NoCache indicates that this layer should not cache its source data
+	NoCache bool `yaml:"nocache"`
 	// Source configures the underlying Source for the layer
 	Source SourceConfig `yaml:"source"`
 }
@@ -50,6 +52,7 @@ type Layer struct {
 	Description string
 	Minzoom     int
 	Maxzoom     int
+	Cacheable   bool
 	Source      Source
 }
 
@@ -60,6 +63,7 @@ func CreateLayer(layerConfig LayerConfig) (*Layer, error) {
 		Description: layerConfig.Description,
 		Minzoom:     layerConfig.Minzoom,
 		Maxzoom:     layerConfig.Maxzoom,
+		Cacheable:   !layerConfig.NoCache,
 	}
 	// TODO: How can we make this more generic?
 	if layerConfig.Source.Elasticsearch != nil && layerConfig.Source.PostGIS != nil {

--- a/layer_test.go
+++ b/layer_test.go
@@ -24,3 +24,17 @@ func TestCreateLayerNoSources(t *testing.T) {
 	_, err := CreateLayer(config)
 	assert.Equal(t, NoSourcesErr, err, "Expected to fail due to no sources for layer")
 }
+
+func TestLayerHashesSame(t *testing.T) {
+	layer := &Layer{Name: "a", source: &NilSource{}}
+	layer2 := &Layer{Name: "a", source: &NilSource{}}
+
+	assert.Equal(t, layer.Hash(), layer2.Hash(), "Excepted identical layers to have the same hash")
+}
+
+func TestLayerHashesDifferent(t *testing.T) {
+	layer := &Layer{Name: "a", source: &NilSource{}}
+	layer2 := &Layer{Name: "b", source: &NilSource{}}
+
+	assert.NotEqual(t, layer.Hash(), layer2.Hash(), "Excepted different layers to have a different hash")
+}

--- a/nil_source.go
+++ b/nil_source.go
@@ -1,0 +1,13 @@
+package tilenol
+
+import (
+	"context"
+
+	"github.com/paulmach/orb/geojson"
+)
+
+type NilSource struct{}
+
+func (n *NilSource) GetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
+	return geojson.NewFeatureCollection(), nil
+}

--- a/nil_source.go
+++ b/nil_source.go
@@ -6,8 +6,10 @@ import (
 	"github.com/paulmach/orb/geojson"
 )
 
+// NilSource implements the Source interface with no data
 type NilSource struct{}
 
+// GetFeatures returns no data for all requests
 func (n *NilSource) GetFeatures(ctx context.Context, req *TileRequest) (*geojson.FeatureCollection, error) {
 	return geojson.NewFeatureCollection(), nil
 }

--- a/server.go
+++ b/server.go
@@ -327,8 +327,8 @@ func (s *Server) getVectorTile(w http.ResponseWriter, r *http.Request) {
 			if s.Simplify {
 				minZoom := layer.Minzoom
 				maxZoom := layer.Maxzoom
-				simplifyThreshold := calculateSimplificationThreshold(minZoom, maxZoom, req.Z)
-				Logger.Debugf("Simplifying @ zoom [%d], epsilon [%f]", req.Z, simplifyThreshold)
+				simplifyThreshold := calculateSimplificationThreshold(minZoom, maxZoom, z)
+				Logger.Debugf("Simplifying @ zoom [%d], epsilon [%f]", z, simplifyThreshold)
 				fcLayer.Simplify(simplify.DouglasPeucker(simplifyThreshold))
 				fcLayer.RemoveEmpty(1.0, 1.0)
 			}

--- a/server.go
+++ b/server.go
@@ -213,7 +213,7 @@ func filterLayersByZoom(inLayers []Layer, z int) []Layer {
 
 // getLayerDataFromSource retrieves layer data from the original backend source
 func (s *Server) getLayerDataFromSource(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {
-	fc, err := layer.Source.GetFeatures(ctx, req)
+	fc, err := layer.GetFeatures(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -260,15 +260,17 @@ func (s *Server) getLayerData(ctx context.Context, layer Layer, req *TileRequest
 		return nil, err
 	}
 
-	// Note: paulmach/orb only implements marshalling code for an array of layer objects,
-	// so we need to wrap the computed fcLayer into a single-item array
-	raw, err := mvt.MarshalGzipped(mvt.Layers{fcLayer})
-	if err != nil {
-		return nil, err
-	}
+	if layer.Cacheable {
+		// Note: paulmach/orb only implements marshalling code for an array of layer objects,
+		// so we need to wrap the computed fcLayer into a single-item array
+		raw, err := mvt.MarshalGzipped(mvt.Layers{fcLayer})
+		if err != nil {
+			return nil, err
+		}
 
-	if err := s.Cache.Put(cacheKey, raw); err != nil {
-		Logger.Warningf("Failed to store layer data in cache [%s]: %s", cacheKey, err)
+		if err := s.Cache.Put(cacheKey, raw); err != nil {
+			Logger.Warningf("Failed to store layer data in cache [%s]: %s", cacheKey, err)
+		}
 	}
 
 	return fcLayer, nil

--- a/server.go
+++ b/server.go
@@ -265,7 +265,7 @@ func (s *Server) getVectorTile(rctx context.Context, w io.Writer, r *http.Reques
 			Logger.Debugf("Retrieving vector tile for layer [%s] @ (%d, %d, %d)", layer.Name, x, y, z)
 
 			cacheKey := fmt.Sprintf("%s/%s", layer, req)
-			if s.Cache.Exists(cacheKey) {
+			if layer.Cacheable && s.Cache.Exists(cacheKey) {
 				Logger.Debugf("Key [%s] found in cache", cacheKey)
 				raw, err := s.Cache.Get(cacheKey)
 				if err != nil {

--- a/server.go
+++ b/server.go
@@ -1,7 +1,6 @@
 package tilenol
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -50,7 +49,7 @@ func (r *TileRequest) String() string {
 				q.Add(k, v)
 			}
 		}
-		s = fmt.Sprintf("%s?%s", s, q.Encode())
+		s = strings.Join([]string{s, q.Encode()}, "?")
 	}
 	return s
 }
@@ -144,9 +143,10 @@ func (s *Server) setupRoutes() (*chi.Mux, *chi.Mux) {
 	}
 
 	//-- ROUTES
-	r.Get("/{layers}/{z}/{x}/{y}.mvt", s.handlerWrapper(s.getVectorTile))
+	r.Get("/{layers}/{z}/{x}/{y}.mvt", s.getVectorTile)
 
 	// TODO: Add GeoJSON endpoint?
+	// TODO: Add TileJSON endpoint (see StationA/tilenol#36)
 
 	i := chi.NewRouter()
 	i.Get("/healthcheck", s.healthCheck)
@@ -173,7 +173,7 @@ func (s *Server) Start() {
 
 // healthCheck implements a simple healthcheck endpoint for the internal metrics server
 func (s *Server) healthCheck(w http.ResponseWriter, r *http.Request) {
-	// TODO: Maybe in the future check that ES is reachable?
+	// TODO: Maybe in the future check that each layer source is reachable?
 	fmt.Fprintf(w, "OK")
 }
 
@@ -211,42 +211,92 @@ func filterLayersByZoom(inLayers []Layer, z int) []Layer {
 	return outLayers
 }
 
-func (s *Server) handlerWrapper(handler Handler) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		defer func() {
-			if ctx.Err() == context.Canceled {
-				Logger.Debugf("Request canceled by client")
-				w.WriteHeader(499)
-				return
-			}
-		}()
-
-		var buffer bytes.Buffer
-		if err := handler(ctx, &buffer, r); err != nil {
-			s.handleError(err, w, r)
-			return
-		}
-
-		// Set standard response headers
-		// TODO: Figure out a smarter cacheing mechanism (see StationA/tilenol#30)
-		w.Header().Set("Cache-Control", "max-age=86400")
-		w.Header().Set("Content-Encoding", "gzip")
-		// TODO: Store the content type somehow in the cache?
-		w.Header().Set("Content-Type", "application/x-protobuf")
-		io.Copy(w, &buffer)
+// getLayerDataFromSource retrieves layer data from the original backend source
+func (s *Server) getLayerDataFromSource(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {
+	fc, err := layer.Source.GetFeatures(ctx, req)
+	if err != nil {
+		return nil, err
 	}
+
+	fcLayer := mvt.NewLayer(layer.Name, fc)
+	fcLayer.Version = 2 // Set to tile spec v2
+	fcLayer.ProjectToTile(req.MapTile())
+	fcLayer.Clip(mvt.MapboxGLDefaultExtentBound)
+	return fcLayer, nil
+}
+
+// getLayerDataFromCache retrieves layer data from the configured cache
+func (s *Server) getLayerDataFromCache(ctx context.Context, cacheKey string) (*mvt.Layer, error) {
+	raw, err := s.Cache.Get(cacheKey)
+	if err != nil {
+		return nil, err
+	}
+	layers, err := mvt.UnmarshalGzipped(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: since we store an mvt.Layers array with only a single layer, we need to pull out
+	// the first layer to match the return interface
+	return layers[0], nil
+}
+
+// getLayerData retrieves layer data either from cache or the original source
+func (s *Server) getLayerData(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {
+	cacheKey := fmt.Sprintf("%s/%s", layer, req)
+	if layer.Cacheable && s.Cache.Exists(cacheKey) {
+		Logger.Debugf("Key [%s] found in cache", cacheKey)
+		if fcLayer, err := s.getLayerDataFromCache(ctx, cacheKey); err == nil {
+			return fcLayer, nil
+		} else {
+			Logger.Warningf("Failed to retrieve layer data from cache [%s]: %s", cacheKey, err)
+		}
+	}
+
+	Logger.Debugf("Key [%s] is not cached", cacheKey)
+
+	fcLayer, err := s.getLayerDataFromSource(ctx, layer, req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Note: paulmach/orb only implements marshalling code for an array of layer objects,
+	// so we need to wrap the computed fcLayer into a single-item array
+	raw, err := mvt.MarshalGzipped(mvt.Layers{fcLayer})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.Cache.Put(cacheKey, raw); err != nil {
+		Logger.Warningf("Failed to store layer data in cache [%s]: %s", cacheKey, err)
+	}
+
+	return fcLayer, nil
 }
 
 // getVectorTile computes a vector tile response for the incoming request
-func (s *Server) getVectorTile(rctx context.Context, w io.Writer, r *http.Request) error {
+func (s *Server) getVectorTile(w http.ResponseWriter, r *http.Request) {
+	rctx := r.Context()
+
+	// Setup deferred error handler for request cancellations
+	defer func() {
+		// TODO: Fix this behavior for certain cancellation scenarios (see StationA/tilenol#42)
+		if rctx.Err() == context.Canceled {
+			Logger.Debugf("Request canceled by client")
+			w.WriteHeader(499)
+			return
+		}
+	}()
+
 	z, _ := strconv.Atoi(chi.URLParam(r, "z"))
 	x, _ := strconv.Atoi(chi.URLParam(r, "x"))
 	y, _ := strconv.Atoi(chi.URLParam(r, "y"))
 	requestedLayers := chi.URLParam(r, "layers")
+
 	req, err := MakeTileRequest(r, x, y, z)
 	if err != nil {
-		return err
+		s.handleError(err, w, r)
+		return
 	}
 
 	var layersToCompute = filterLayersByZoom(s.Layers, z)
@@ -261,72 +311,55 @@ func (s *Server) getVectorTile(rctx context.Context, w io.Writer, r *http.Reques
 	fcLayers := make(mvt.Layers, len(layersToCompute))
 	for i, layer := range layersToCompute {
 		i, layer := i, layer // Fun stuff: https://blog.cloudflare.com/a-go-gotcha-when-closures-and-goroutines-collide/
+
+		// Start a goroutine for each layer
 		eg.Go(func() error {
-			Logger.Debugf("Retrieving vector tile for layer [%s] @ (%d, %d, %d)", layer.Name, x, y, z)
+			Logger.Debugf("Retrieving layer data for [%s] @ (%d, %d, %d)", layer, z, x, y)
 
-			cacheKey := fmt.Sprintf("%s/%s", layer, req)
-			if layer.Cacheable && s.Cache.Exists(cacheKey) {
-				Logger.Debugf("Key [%s] found in cache", cacheKey)
-				raw, err := s.Cache.Get(cacheKey)
-				if err != nil {
-					Logger.Warningf("Failed to retrieve layer data from cache [%s]: %s", cacheKey, err)
-					goto CacheFailure
-				}
-				layers, err := mvt.UnmarshalGzipped(raw)
-				if err != nil {
-					Logger.Warningf("Failed to decode layer data in cache [%s]: %s", cacheKey, err)
-					goto CacheFailure
-				}
-				// Note that only one layer should be stored in cache per key
-				fcLayers[i] = layers[0]
-				return nil
-			}
-
-		CacheFailure:
-			Logger.Debugf("Key [%s] is not cached", cacheKey)
-			fc, err := layer.Source.GetFeatures(ctx, req)
+			fcLayer, err := s.getLayerData(ctx, layer, req)
 			if err != nil {
 				return err
 			}
-			fcLayer := mvt.NewLayer(layer.Name, fc)
-			fcLayer.Version = 2 // Set to tile spec v2
-			fcLayer.ProjectToTile(req.MapTile())
-			fcLayer.Clip(mvt.MapboxGLDefaultExtentBound)
 
+			// TODO: Consider the tradeoffs of cacheing pre-simplified vs. post-simplified layers
 			if s.Simplify {
 				minZoom := layer.Minzoom
 				maxZoom := layer.Maxzoom
-				simplifyThreshold := calculateSimplificationThreshold(minZoom, maxZoom, z)
-				Logger.Debugf("Simplifying @ zoom [%d], epsilon [%f]", z, simplifyThreshold)
+				simplifyThreshold := calculateSimplificationThreshold(minZoom, maxZoom, req.Z)
+				Logger.Debugf("Simplifying @ zoom [%d], epsilon [%f]", req.Z, simplifyThreshold)
 				fcLayer.Simplify(simplify.DouglasPeucker(simplifyThreshold))
 				fcLayer.RemoveEmpty(1.0, 1.0)
-			}
-
-			raw, err := mvt.MarshalGzipped(mvt.Layers{fcLayer})
-			if err != nil {
-				return err
-			}
-			if err := s.Cache.Put(cacheKey, raw); err != nil {
-				Logger.Warningf("Failed to store layer data in cache [%s]: %s", cacheKey, err)
 			}
 
 			fcLayers[i] = fcLayer
 			return nil
 		})
 	}
+
 	// Wait for all of the goroutines spawned in this errgroup to complete or fail
 	if err := eg.Wait(); err != nil {
 		// If any of them fail, return the error
-		return err
+		s.handleError(err, w, r)
+		return
 	}
 
 	// Lastly, marshal the object into the response output
 	data, marshalErr := mvt.MarshalGzipped(fcLayers)
 	if marshalErr != nil {
-		return marshalErr
+		s.handleError(marshalErr, w, r)
+		return
 	}
-	_, err = w.Write(data)
-	return err
+
+	// Set standard response headers
+	// TODO: Figure out a smarter cacheing mechanism (see StationA/tilenol#30)
+	w.Header().Set("Cache-Control", "max-age=86400")
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Content-Type", "application/x-protobuf")
+
+	if _, err := w.Write(data); err != nil {
+		s.handleError(err, w, r)
+		return
+	}
 }
 
 // handleError is a helper function to generate a generic tile server error response

--- a/server.go
+++ b/server.go
@@ -43,7 +43,7 @@ type TileRequest struct {
 func (r *TileRequest) String() string {
 	var s = fmt.Sprintf("%d/%d/%d", r.Z, r.X, r.Y)
 	if len(r.Args) > 0 {
-		var q url.Values
+		q := make(url.Values)
 		for k, vs := range r.Args {
 			for _, v := range vs {
 				q.Add(k, v)
@@ -243,7 +243,7 @@ func (s *Server) getLayerDataFromCache(ctx context.Context, cacheKey string) (*m
 
 // getLayerData retrieves layer data either from cache or the original source
 func (s *Server) getLayerData(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {
-	cacheKey := fmt.Sprintf("%s/%s", layer, req)
+	cacheKey := fmt.Sprintf("%s/%s", layer.String(), req.String())
 	if layer.Cacheable && s.Cache.Exists(cacheKey) {
 		Logger.Debugf("Key [%s] found in cache", cacheKey)
 		if fcLayer, err := s.getLayerDataFromCache(ctx, cacheKey); err == nil {

--- a/server_test.go
+++ b/server_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
-	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -100,7 +99,7 @@ func TestCachedHandler(t *testing.T) {
 		Layer{Cacheable: true, Source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
-	handler := http.HandlerFunc(server.getVectorTile)
+	handler, _ := server.setupRoutes()
 
 	for i := 0; i < 100; i++ {
 		body := ioutil.NopCloser(bytes.NewReader([]byte{}))
@@ -125,7 +124,7 @@ func TestUnCachedHandler(t *testing.T) {
 		Layer{Cacheable: true, Source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
-	handler := http.HandlerFunc(server.getVectorTile)
+	handler, _ := server.setupRoutes()
 
 	for i := 0; i < 100; i++ {
 		body := ioutil.NopCloser(bytes.NewReader([]byte{}))
@@ -148,11 +147,11 @@ func TestLayerCacheability(t *testing.T) {
 	cachedSource := &countingSource{Source: &NilSource{}}
 	cache := &countingCache{Cache: NewInMemoryCache()}
 	layers := []Layer{
-		Layer{Cacheable: true, Source: cachedSource},
-		Layer{Cacheable: false, Source: source},
+		Layer{Name: "cacheable", Cacheable: true, Source: cachedSource},
+		Layer{Name: "not-cacheable", Cacheable: false, Source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
-	handler := http.HandlerFunc(server.getVectorTile)
+	handler, _ := server.setupRoutes()
 
 	for i := 0; i < 100; i++ {
 		body := ioutil.NopCloser(bytes.NewReader([]byte{}))

--- a/server_test.go
+++ b/server_test.go
@@ -96,7 +96,7 @@ func TestCachedHandler(t *testing.T) {
 	source := &countingSource{Source: &NilSource{}}
 	cache := &countingCache{Cache: NewInMemoryCache()}
 	layers := []Layer{
-		Layer{Cacheable: true, Source: source},
+		Layer{Cacheable: true, source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
 	handler, _ := server.setupRoutes()
@@ -121,7 +121,7 @@ func TestUnCachedHandler(t *testing.T) {
 	source := &countingSource{Source: &NilSource{}}
 	cache := &countingCache{Cache: &NilCache{}}
 	layers := []Layer{
-		Layer{Cacheable: true, Source: source},
+		Layer{Cacheable: true, source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
 	handler, _ := server.setupRoutes()
@@ -147,8 +147,8 @@ func TestLayerCacheability(t *testing.T) {
 	cachedSource := &countingSource{Source: &NilSource{}}
 	cache := &countingCache{Cache: NewInMemoryCache()}
 	layers := []Layer{
-		Layer{Name: "cacheable", Cacheable: true, Source: cachedSource},
-		Layer{Name: "not-cacheable", Cacheable: false, Source: source},
+		Layer{Name: "cacheable", Cacheable: true, source: cachedSource},
+		Layer{Name: "not-cacheable", Cacheable: false, source: source},
 	}
 	server := &Server{Layers: layers, Cache: cache}
 	handler, _ := server.setupRoutes()

--- a/server_test.go
+++ b/server_test.go
@@ -167,8 +167,11 @@ func TestLayerCacheability(t *testing.T) {
 	if !(source.GetCounter == 100) {
 		t.Errorf("Requests should not be cached for the not-cacheable layer: %d", source.GetCounter)
 	}
-	if !(cachedSource.GetCounter == 1) {
+	if !(cachedSource.GetCounter == 1 && cache.GetCounter == 99) {
 		t.Errorf("Requests should be cached for the cacheable layer: %d", cachedSource.GetCounter)
+	}
+	if !(cache.PutCounter == 1) {
+		t.Errorf("Request should only put cache values for cacheable layers once: %d", cache.PutCounter)
 	}
 }
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,13 @@
+package tilenol
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Disable logging
+	Logger.SetOutput(ioutil.Discard)
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
This changeset closes #25 by implementing a simple cache-per-layer approach (as opposed to the current approach of cache-per-URL). At a high level, this is how the new caching approach works:

- When a request comes in for one or more layers, we do the following for each layer:
  - We create a cache key, by composing together a stringified representation of the layer and the tile request
    - A layer is stringified by composing its name and a content-based hash (SHA256) of its effective configuration; the idea here is that the hash should only change when its configuration changes, but should be the same across restarts
    - A tile request is stringified by composing the `z`, `x`, and `y`, values, along with any additional query parameters
    - The cache key format roughly resembles: `{layer}@{layer-sha256}/{z}/{x}/{y}?{args}`
  - If the current layer is cacheable (configured with `nocache: false`, which is the default when omitted), then we first check to see if the layer data is stored in the cache at the computed key; otherwise, we pull the layer data from its backend source
  - Also, if the current layer is cacheable, we then marshal the layer data into the raw GZIPed MVT binary format and store it at the computed cache key
  - Lastly, we return the in-memory layer data to the caller

With these changes in place, we get a few major improvements:

1. **Improved cache hit ratio for multi-layer configurations**: because this now caches per layer vs. per URL/request, we should see moderate performance improvements for mixed-combination tile requests, e.g. a request to something like `/_all/z/x/y.mvt`, followed by `/layer1/z/x/y.mvt`, should hit the `layer1` cache on the second request, since `layer1` gets cached in the first request at a more granular cache key
2. **More fine-grained control for the caching behavior of multi-layer configurations**: there's still room for improvement, but between computing hash keys per layer (vs. per URL), and exposing the optional `nocache` option for each configured layer, this adds an extra level of flexibility
3. **Better path forward for reconfigurations**: previously there was some buggy cache behavior when reconfiguring a layer under the cache-per-URL implementation, as the URL doesn't change even if your layer configuration does; by using the configuration in the cache key (using the configuration hash digest), we can ensure that layer data is freshly retrieved whenever its configuration changes, and that layer cache data is reused when the configuration is the same
4. **Better resilience to cache failure**: previously, if retrieving data from the cache failed for any reason, we would fail the entire request; in this revised implementation, cache retrieval failures are treated the same as a cache miss, which should fix a broad class of potential issues (e.g. temporary network failures, bad data/deserialization issues, etc.)

That said, there are a couple of potential new thoughts that come out of this:

* The cache configuration is still global (including things like TTL); since we now have additional cache controls per layer, should we instead consider moving the cache configuration as a whole into each layer? Is there some hybrid approach where each layer could instead reference a global cache?
* In this implementation, there is some additional serialization/deserialization overhead that has been introduced between the tilenol server and the backend cache; what is the impact of this overhead and are there alternative ways to approach layer data serialization to avoid this overhead?