### PR TITLE
Remove empty geometries before marshaling.

### DIFF
--- a/server.go
+++ b/server.go
@@ -215,19 +215,17 @@ func filterLayersByZoom(inLayers []Layer, z int) []Layer {
 	return outLayers
 }
 
-
 // Filter out Features with an empty geometry in a Layer.
 func filterEmptyGeometries(layer *mvt.Layer) {
-        count := 0
+	count := 0
 	for _, f := range layer.Features {
 		if f.Geometry != nil {
-		        layer.Features[count] = f
+			layer.Features[count] = f
 			count++
 		}
 	}
 	layer.Features = layer.Features[:count]
 }
-
 
 // getLayerDataFromSource retrieves layer data from the original backend source
 func (s *Server) getLayerDataFromSource(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {

--- a/server.go
+++ b/server.go
@@ -263,6 +263,7 @@ func (s *Server) getLayerData(ctx context.Context, layer Layer, req *TileRequest
 	if err != nil {
 		return nil, err
 	}
+	fcLayer.RemoveEmpty(1.0, 1.0)
 
 	if layer.Cacheable {
 		// Note: paulmach/orb only implements marshalling code for an array of layer objects,

--- a/server.go
+++ b/server.go
@@ -215,6 +215,20 @@ func filterLayersByZoom(inLayers []Layer, z int) []Layer {
 	return outLayers
 }
 
+
+// Filter out Features with an empty geometry in a Layer.
+func filterEmptyGeometries(layer *mvt.Layer) {
+        count := 0
+	for _, f := range layer.Features {
+		if f.Geometry != nil {
+		        layer.Features[count] = f
+			count++
+		}
+	}
+	layer.Features = layer.Features[:count]
+}
+
+
 // getLayerDataFromSource retrieves layer data from the original backend source
 func (s *Server) getLayerDataFromSource(ctx context.Context, layer Layer, req *TileRequest) (*mvt.Layer, error) {
 	fc, err := layer.GetFeatures(ctx, req)
@@ -263,7 +277,7 @@ func (s *Server) getLayerData(ctx context.Context, layer Layer, req *TileRequest
 	if err != nil {
 		return nil, err
 	}
-	fcLayer.RemoveEmpty(1.0, 1.0)
+	filterEmptyGeometries(fcLayer)
 
 	if layer.Cacheable {
 		// Note: paulmach/orb only implements marshalling code for an array of layer objects,


### PR DESCRIPTION
# Description

This PR fixes an issue that causes tilenol to crash if a layer returned contains an empty geometry (stack trace below).

The issue is that tilenol attempts to Marshal layers into a gzipped MVT before storing it in the optional cache. However, Marshaling a Layer into a gzipped MVT via `mvt.MarshalGzipped` causes a panic if an empty geometry is encountered.

This one-line fix adds a call to [Layer.removeEmpty](https://github.com/paulmach/orb/blob/dcade4901baea0727377ccf7c4aab2addd92d152/encoding/mvt/simplify.go#L40) after retrieving it from the source, but before marshaling it for storage in the cache. This function also removes empty geometries (not just too small ones), and hence the issue is avoided.

## Testing Done
* Confirmed that I can no longer reproduce the crash with the patch.
* Testing shows that MVTs served by tilenol seem otherwise unaffected.

```
panic: geometry type not supported: <nil>

goroutine 258 [running]:
github.com/paulmach/orb/encoding/mvt.encodeGeometry(0x0, 0x0, 0x0, 0x2, 0x2, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/paulmach/orb@v0.1.6/encoding/mvt/geometry.go:90 +0x1d37
github.com/paulmach/orb/encoding/mvt.Marshal(0xc0005c7cb8, 0x1, 0x1, 0x0, 0x7, 0xc0001e8130, 0xc0003880f0, 0xc000442e40)
	/go/pkg/mod/github.com/paulmach/orb@v0.1.6/encoding/mvt/marshal.go:60 +0x126
github.com/paulmach/orb/encoding/mvt.MarshalGzipped(0xc0005c7cb8, 0x1, 0x1, 0xc0001e8130, 0x7, 0x0, 0x0, 0xe)
	/go/pkg/mod/github.com/paulmach/orb@v0.1.6/encoding/mvt/marshal.go:21 +0x5a
github.com/stationa/tilenol.(*Server).getLayerData(0xc000183bf0, 0xdfb080, 0xc0002eeb00, 0xc0001e8130, 0x7, 0x0, 0x0, 0xe, 0x0, 0x1, ...)
	/go/src/github.com/stationa/tilenol/server.go:266 +0x345
github.com/stationa/tilenol.(*Server).getVectorTile.func2(0x0, 0x0)
	/go/src/github.com/stationa/tilenol/server.go:321 +0x308
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000388690, 0xc0003864d0)
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	/go/pkg/mod/golang.org/x/sync@v0.0.0-20201020160332-67f06af15bc9/errgroup/errgroup.go:54 +0x66
```